### PR TITLE
Add simulation state module and simple React UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Virtual Trading Practice</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+</head>
+<body>
+    <div id="app"></div>
+    <script type="module" src="./src/app.js"></script>
+</body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,48 @@
+import { Simulation } from './simulation.js';
+
+const simulation = new Simulation();
+
+function App() {
+    const [state, setState] = React.useState(simulation.state);
+
+    React.useEffect(() => {
+        const unsubscribe = simulation.subscribe(setState);
+        return unsubscribe;
+    }, []);
+
+    const buy = () => simulation.buy('AAPL', 100, 1);
+    const sell = () => simulation.sell('AAPL', 100, 1);
+
+    return React.createElement(
+        'div',
+        null,
+        React.createElement('h1', null, 'Virtual Trading Practice'),
+        React.createElement('div', null, `Balance: $${state.balance}`),
+        React.createElement(
+            'button',
+            { onClick: buy },
+            'Buy 1 AAPL @ $100'
+        ),
+        React.createElement(
+            'button',
+            { onClick: sell },
+            'Sell 1 AAPL @ $100'
+        ),
+        React.createElement(
+            'ul',
+            null,
+            state.positions.map((p, i) =>
+                React.createElement(
+                    'li',
+                    { key: i },
+                    `${p.qty} ${p.symbol} @ $${p.price}`
+                )
+            )
+        )
+    );
+}
+
+ReactDOM.render(
+    React.createElement(App),
+    document.getElementById('app')
+);

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -1,0 +1,39 @@
+export class Simulation {
+    constructor(initialBalance = 10000) {
+        this.state = {
+            balance: initialBalance,
+            positions: []
+        };
+        this.subscribers = new Set();
+    }
+
+    subscribe(handler) {
+        this.subscribers.add(handler);
+        // Immediately send current state to new subscriber
+        handler({...this.state});
+        return () => this.subscribers.delete(handler);
+    }
+
+    _notify() {
+        for (const handler of this.subscribers) {
+            handler({...this.state});
+        }
+    }
+
+    buy(symbol, price, qty) {
+        this.state.balance -= price * qty;
+        this.state.positions.push({ symbol, price, qty });
+        this._notify();
+    }
+
+    sell(symbol, price, qty) {
+        const index = this.state.positions.findIndex(
+            p => p.symbol === symbol && p.price === price && p.qty === qty
+        );
+        if (index !== -1) {
+            this.state.positions.splice(index, 1);
+            this.state.balance += price * qty;
+            this._notify();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple simulation state manager under `src/simulation.js`
- create a minimal React interface in `src/app.js`
- load the new UI via `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886ead6ed708322aa14c0e60d476f60